### PR TITLE
feat: Add Python3 shebang and fix Qt attribute setting

### DIFF
--- a/nparse.py
+++ b/nparse.py
@@ -218,11 +218,11 @@ if __name__ == "__main__":
     except:
         pass
 
+    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
     APP = NomnsParse(sys.argv)
     APP.setStyleSheet(open(resource_path('data/ui/_.css')).read())
     APP.setWindowIcon(QIcon(resource_path('data/ui/icon.png')))
     APP.setQuitOnLastWindowClosed(False)
-    APP.setAttribute(Qt.AA_EnableHighDpiScaling)
     QFontDatabase.addApplicationFont(
         resource_path('data/fonts/NotoSans-Regular.ttf'))
     QFontDatabase.addApplicationFont(

--- a/nparse.py
+++ b/nparse.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """NomnsParse: Parsing tools TAKP Fork."""
 import os
 import sys


### PR DESCRIPTION
### Summary
This pull request includes the following changes:
1. **Add shebang line for Python3**: Added the shebang line `#!/usr/bin/env python3` at the top of the script to ensure it runs with Python 3.
2. **Fix Qt::AA_EnableHighDpiScaling attribute setting**: Moved the setting of the `Qt::AA_EnableHighDpiScaling` attribute before the creation of `QCoreApplication` to fix the error: "Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created."

### Details
- **Add shebang line for Python3**: This change ensures that the script runs with Python 3 by default.
- **Fix Qt::AA_EnableHighDpiScaling attribute setting**: This change addresses an error related to the order of setting the `Qt::AA_EnableHighDpiScaling` attribute, ensuring it is set before the creation of `QCoreApplication`.

### Testing
- Verified that the script runs with Python 3.
- Confirmed that the error related to `Qt::AA_EnableHighDpiScaling` is resolved.